### PR TITLE
Fix for OpenAPI issue : 16556

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 - Entities annotated with `@cds.autoexpose[d]` but explicitly exposed in the service are now made read-write.
+- Enum array are now included in the schema of the entity having an enum property.
 
 ## Version 1.0.5 - 30.07.2024
 

--- a/lib/compile/csdl2openapi.js
+++ b/lib/compile/csdl2openapi.js
@@ -2214,6 +2214,11 @@ see [Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-prot
             s.example = element[voc.Core.Example].Value;
         }
 
+        if (element.$UnderlyingType && element[voc.Validation.AllowedValues]) {
+            const values = element[voc.Validation.AllowedValues];
+            s.enum = values.map(item => item["@Core.SymbolicName"]);
+        } 
+
         if (forFunction) {
             if (s.example && typeof s.example === "string") {
                 s.example = `${pathValuePrefix(element.$Type)}${s.example


### PR DESCRIPTION
This PR, contains fix for the issue - https://github.tools.sap/cap/issues/issues/16556

Sample CDS:


```
namespace my.namespace;

service MyService {
    entity MyEntity {
        key id     : String;
            status : statusEnum;
    }

    type statusEnum : String enum {
        active;
        inactive;
    }
}

```

Now in the generated OpenAPI document the enum will be added like the below:
<img width="569" alt="image" src="https://github.com/user-attachments/assets/7d6231c2-6eff-4289-b9c0-bf04708ee02c">
