### PR TITLE
[CDSADAPTERS-2132] Openapi compile: Options input provided in JSON file #16882

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Initial release
+- Introduced --openapi:config-file option to incorporate all the options for cds compile command in a JSON configuration file, inline options take precedence over those defined in the configuration file.

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -1,29 +1,30 @@
 const csdl2openapi = require('./csdl2openapi')
 const cds = require('@sap/cds/lib');
+const fs = require("fs");
 
 module.exports = function processor(csn, options = {}) {
-    const edmOptions = Object.assign({
-        odataOpenapiHints: true, // hint to cds-compiler
-        edm4OpenAPI: true, // downgrades certain OData errors to warnings in cds-compiler
-        to: 'openapi' // hint to cds.compile.to.edm (usually set by CLI, but also do this in programmatic usages)
-    }, options)
+  const edmOptions = Object.assign({
+    odataOpenapiHints: true, // hint to cds-compiler
+    edm4OpenAPI: true, // downgrades certain OData errors to warnings in cds-compiler
+    to: 'openapi' // hint to cds.compile.to.edm (usually set by CLI, but also do this in programmatic usages)
+  }, options)
 
-    // must not be part of function* otherwise thrown errors are swallowed
-    const csdl = cds.compile.to.edm(csn, edmOptions);
-    let openApiDocs = {};
+  // must not be part of function* otherwise thrown errors are swallowed
+  const csdl = cds.compile.to.edm(csn, edmOptions);
+  let openApiDocs = {};
 
-    if (csdl[Symbol.iterator]) { // generator function means multiple services
-        openApiDocs = _getOpenApiForMultipleServices(csdl, csn, options)
-    } else {
-        const openApiOptions = toOpenApiOptions(csdl, csn, options)
-        openApiDocs = _getOpenApi(csdl, openApiOptions);
-    }
+  if (csdl[Symbol.iterator]) { // generator function means multiple services
+    openApiDocs = _getOpenApiForMultipleServices(csdl, csn, options)
+  } else {
+    const openApiOptions = toOpenApiOptions(csdl, csn, options)
+    openApiDocs = _getOpenApi(csdl, openApiOptions);
+  }
 
-    if(Object.keys(openApiDocs).length == 1){
-        return openApiDocs[Object.keys(openApiDocs)[0]];
-    }
+  if (Object.keys(openApiDocs).length == 1) {
+    return openApiDocs[Object.keys(openApiDocs)[0]];
+  }
 
-    return _iterate(openApiDocs);
+  return _iterate(openApiDocs);
 }
 
 function _getOpenApiForMultipleServices(csdl, csn, options) {
@@ -88,25 +89,23 @@ function toOpenApiOptions(csdl, csn, options = {}) {
     }
   }
 
-  if (result["config-file"]) {
-    try {
-      const fileContent = require(result["config-file"]);
-      for (let key in fileContent) {
-        if (key === "odata-version" && result["odataVersion"] || key in result) {
-          delete fileContent[key];
-        } else if (key === "odata-version") {
-          result["odataVersion"] = fileContent[key];
-        } else if (key === "diagram") {
-          result["diagram"] = fileContent[key] === "true" ? true : false;
-        } else {
-          result[key] = JSON.stringify(fileContent[key]);
-        }
-      }
-      delete result["config-file"];
-    } catch (error) {
-      console.log(error);
+  if (result["config-file"]){
+    if(fs.existsSync(result["config-file"])) {
+    const fileContent = require(result["config-file"]);
+    Object.keys(fileContent).forEach((key) => {
+    if (!(key in result)) {  // inline options take precedence
+      result[key] = JSON.stringify(fileContent[key]);
     }
+      if (key === "odata-version" && !result["odataVersion"]) {
+        result["odataVersion"] = fileContent[key];
+      } else if (key === "diagram") {
+        result["diagram"] = !result["diagram"] && fileContent[key] === "true";
+      }
+    });
+  } else {
+    throw new Error("Error while parsing the openapi configuration file");
   }
+}
 
   const protocols = _getProtocols(csdl, csn);
 

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -88,6 +88,26 @@ function toOpenApiOptions(csdl, csn, options = {}) {
     }
   }
 
+  if (result["config-file"]) {
+    try {
+      const fileContent = require(result["config-file"]);
+      for (let key in fileContent) {
+        if (key === "odata-version" && result["odataVersion"] || key in result) {
+          delete fileContent[key];
+        } else if (key === "odata-version") {
+          result["odataVersion"] = fileContent[key];
+        } else if (key === "diagram") {
+          result["diagram"] = fileContent[key] === "true" ? true : false;
+        } else {
+          result[key] = JSON.stringify(fileContent[key]);
+        }
+      }
+      delete result["config-file"];
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
   const protocols = _getProtocols(csdl, csn);
 
   if (result.url) {


### PR DESCRIPTION
Added the cds compile --openapi:config-file option to incorporate all the options in a JSON file as some options were inconsistent in different systems. Inline options are also given more precedence than those defined in the configuration file(JSON).

Github issue: https://github.tools.sap/cap/issues/issues/16882
JIRA link: https://jira.tools.sap/browse/CDSADAPTERS-2132