### PR TITLE
[CDSADAPTERS-2132] Added --openapi:config-file option for openapi compile and test cases for the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Initial release
+- Introduced --openapi:config-file option to incorporate all the options for cds compile command in a JSON configuration file, inline options take precedence over those defined in the configuration file.

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -1,29 +1,30 @@
 const csdl2openapi = require('./csdl2openapi')
 const cds = require('@sap/cds/lib');
+const fs = require("fs");
 
 module.exports = function processor(csn, options = {}) {
-    const edmOptions = Object.assign({
-        odataOpenapiHints: true, // hint to cds-compiler
-        edm4OpenAPI: true, // downgrades certain OData errors to warnings in cds-compiler
-        to: 'openapi' // hint to cds.compile.to.edm (usually set by CLI, but also do this in programmatic usages)
-    }, options)
+  const edmOptions = Object.assign({
+    odataOpenapiHints: true, // hint to cds-compiler
+    edm4OpenAPI: true, // downgrades certain OData errors to warnings in cds-compiler
+    to: 'openapi' // hint to cds.compile.to.edm (usually set by CLI, but also do this in programmatic usages)
+  }, options)
 
-    // must not be part of function* otherwise thrown errors are swallowed
-    const csdl = cds.compile.to.edm(csn, edmOptions);
-    let openApiDocs = {};
+  // must not be part of function* otherwise thrown errors are swallowed
+  const csdl = cds.compile.to.edm(csn, edmOptions);
+  let openApiDocs = {};
 
-    if (csdl[Symbol.iterator]) { // generator function means multiple services
-        openApiDocs = _getOpenApiForMultipleServices(csdl, csn, options)
-    } else {
-        const openApiOptions = toOpenApiOptions(csdl, csn, options)
-        openApiDocs = _getOpenApi(csdl, openApiOptions);
-    }
+  if (csdl[Symbol.iterator]) { // generator function means multiple services
+    openApiDocs = _getOpenApiForMultipleServices(csdl, csn, options)
+  } else {
+    const openApiOptions = toOpenApiOptions(csdl, csn, options)
+    openApiDocs = _getOpenApi(csdl, openApiOptions);
+  }
 
-    if(Object.keys(openApiDocs).length == 1){
-        return openApiDocs[Object.keys(openApiDocs)[0]];
-    }
+  if (Object.keys(openApiDocs).length == 1) {
+    return openApiDocs[Object.keys(openApiDocs)[0]];
+  }
 
-    return _iterate(openApiDocs);
+  return _iterate(openApiDocs);
 }
 
 function _getOpenApiForMultipleServices(csdl, csn, options) {
@@ -85,6 +86,23 @@ function toOpenApiOptions(csdl, csn, options = {}) {
       result[RegExp.$1] = options[key];
     } else if (key === "odata-version") {
       result["odataVersion"] = options[key];
+    }
+  }
+
+  if (result["config-file"]) {
+    if (fs.existsSync(result["config-file"])) {
+      const fileContent = require(result["config-file"]);
+      Object.keys(fileContent).forEach((key) => {
+        if (key === "odata-version" && !result["odataVersion"]) {
+          result["odataVersion"] = fileContent[key];
+        } else if (key === "diagram") {
+          result["diagram"] = !result["diagram"] && fileContent[key] === "true";
+        } else if (!(key in result)) {  // inline options take precedence
+          result[key] = JSON.stringify(fileContent[key]);
+        }
+      });
+    } else {
+      throw new Error("Error while parsing the openapi configuration file");
     }
   }
 

--- a/test/lib/compile/data/configFile.json
+++ b/test/lib/compile/data/configFile.json
@@ -1,0 +1,13 @@
+{
+    "url": "http://foo.bar:3000",
+    "servers": [
+        {
+            "url": "http://foo.bar:8080"
+        },
+        {
+            "url": "http://foo.bar:8080/a/foo"
+        }
+    ],
+    "odata-version": "4.1",
+    "diagram":"true"
+}

--- a/test/lib/compile/openapi.test.js
+++ b/test/lib/compile/openapi.test.js
@@ -245,13 +245,13 @@ describe('OpenAPI export', () => {
     const openapi = toOpenApi(csn, { 'openapi:config-file': path.resolve("./test/lib/compile/data/configFile.json") });
     expect(openapi.servers).toBeTruthy();
     expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080/rest/A' }, { url: "http://foo.bar:8080/a/foo/rest/A" }] });
-    expect(openapi.info.description).toMatch(/yuml.*diagram/i);
+    expect(openapi.info.description).toMatch(/yuml.*diagram/i); 
     expect(openapi['x-odata-version']).toMatch('4.1');
   });
 
   test('options: config-file - with inline options, inline options given precedence', () => {
     const csn = cds.compile.to.csn(`
-      service A {entity E { key ID : UUID; };};`
+       @title:'It is located at http://example.com:8080' service A {entity E { key ID : UUID;};};`
     );
     const options = {
       'openapi:config-file': path.resolve("./test/lib/compile/data/configFile.json"),
@@ -260,7 +260,7 @@ describe('OpenAPI export', () => {
       'openapi:diagram': "false"
     }
     const openapi = toOpenApi(csn, options);
-    expect(openapi.info.description).toMatch(/http:\/\/example.com:8080/i);
+    expect(openapi.info.title).toMatch(/http:\/\/example.com:8080/i)
     expect(openapi.info.description).not.toMatch(/yuml.*diagram/i);
     expect(openapi['x-odata-version']).toMatch('4.0');
     expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080/odata/v4/A' }, { url: "http://foo.bar:8080/a/foo/odata/v4/A" }] });

--- a/test/lib/compile/openapi.test.js
+++ b/test/lib/compile/openapi.test.js
@@ -1,3 +1,4 @@
+const { path } = require('@sap/cds/lib/utils/cds-utils');
 const toOpenApi = require('../../../lib/compile');
 const cds = require('@sap/cds')
 
@@ -236,6 +237,34 @@ describe('OpenAPI export', () => {
     catch (e) {
       expect(e.message).toBe("The input server object is invalid.");
     }
+  });
+
+  test('options: config-file - without inline options', () => {
+    const csn = cds.compile.to.csn(`
+      service A {entity E { key ID : UUID; };};`
+    );
+    const openapi = toOpenApi(csn, { 'openapi:config-file': path.resolve("./test/lib/compile/data/configFile.json") });
+    expect(openapi.servers).toBeTruthy();
+    expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080/rest/A' }, { url: "http://foo.bar:8080/a/foo/rest/A" }] });
+    expect(openapi.info.description).toMatch(/yuml.*diagram/i);
+    expect(openapi['x-odata-version']).toMatch('4.1');
+  });
+
+  test('options: config-file - with inline options, inline options given precedence', () => {
+    const csn = cds.compile.to.csn(`
+      service A {entity E { key ID : UUID; };};`
+    );
+    const options = {
+      'openapi:config-file': path.resolve("./test/lib/compile/data/configFile.json"),
+      'openapi:url': "http://example.com:8080",
+      'odata-version': '4.0',
+      'openapi:diagram': "false"
+    }
+    const openapi = toOpenApi(csn, options);
+    expect(openapi.info.description).toMatch(/http:\/\/example.com:8080/i);
+    expect(openapi.info.description).not.toMatch(/yuml.*diagram/i);
+    expect(openapi['x-odata-version']).toMatch('4.0');
+    expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080/odata/v4/A' }, { url: "http://foo.bar:8080/a/foo/odata/v4/A" }] });
   });
 
   test('annotations: root entity property', () => {


### PR DESCRIPTION
Added the cds compile --openapi:config-file option to incorporate all the options in a JSON file as some options were inconsistent in different systems. Inline options are also given more precedence than those defined in the configuration file(JSON). Apart from that test cases are also defined for the same.

Github issue: https://github.tools.sap/cap/issues/issues/16882
JIRA link: https://jira.tools.sap/browse/CDSADAPTERS-2132