### PR TITLE
Removing duplicates in tags object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Fixed
 
+- Removed duplicates in `tags`.
+
+
+### Fixed
+
 - Multiple protocols for a service now renders multiple openapi documents.
 - Format and type are now preserved for function parameters.
 

--- a/lib/compile/csdl2openapi.js
+++ b/lib/compile/csdl2openapi.js
@@ -496,18 +496,19 @@ module.exports.csdl2openapi = function (
      * @return {Array} The list of tags
      */
     function getTags(container) {
-        const tags = [];
-        // all entity sets and singletons
-        Object.keys(container).filter(name => isIdentifier(name) && container[name].$Type).forEach(child => {
-            const type = modelElement(container[child].$Type) || {};
-            const tag = {
-                name: type[voc.Common.Label] || child
-            };
-            const description = container[child][voc.Core.Description] || type[voc.Core.Description];
-            if (description) tag.description = description;
-            tags.push(tag);
-        })
-        return tags.sort(function (pre, next) { return pre.name.localeCompare(next.name) });
+        const tags = new Map();
+        Object.keys(container)
+            .filter(name => isIdentifier(name) && container[name].$Type)
+            .forEach(child => {
+                const type = modelElement(container[child].$Type) || {};
+                const tag = {
+                    name: type[voc.Common.Label] || child
+                };
+                const description = container[child][voc.Core.Description] || type[voc.Core.Description];
+                if (description) tag.description = description;
+                tags.set(tag.name, tag);
+            });
+        return Array.from(tags.values()).sort((pre, next) => pre.name.localeCompare(next.name));
     }
 
     /**

--- a/lib/compile/csdl2openapi.js
+++ b/lib/compile/csdl2openapi.js
@@ -497,6 +497,7 @@ module.exports.csdl2openapi = function (
      */
     function getTags(container) {
         const tags = new Map();
+         // all entity sets and singletons
         Object.keys(container)
             .filter(name => isIdentifier(name) && container[name].$Type)
             .forEach(child => {

--- a/test/lib/compile/csdl2openapi.test.js
+++ b/test/lib/compile/csdl2openapi.test.js
@@ -101,24 +101,8 @@ describe('Edge cases', function () {
         };
         const openapi = lib.csdl2openapi(csdl, {});
         assert.deepStrictEqual(openapi, expected, 'Empty CSDL document');
-    })
-
-    it('tags object exists and it does not have duplicates', function () {
-        const csdl = {
-            $EntityContainer: 'this.Container',
-            this: {
-                ET: { $Kind: 'EntityType', $Key: ['key'], key
-                : {} },
-                Container: {
-                    Set: { $Type: 'this.ET', $Collection: true }
-                }
-            }
-        };
-        const openapi = lib.csdl2openapi(csdl, {});
-        assert.ok(openapi.tags, 'Tags object exists');
-        assert.strictEqual(openapi.tags.length, 1, 'Tags object does not have duplicates');
-    })
-
+    });
+    
     it('omit unused types', function () {
         const csdl = {
             $Reference: { dummy: { '$Include': [{ '$Namespace': 'Org.OData.Core.V1', '$Alias': 'Core' }] } },

--- a/test/lib/compile/csdl2openapi.test.js
+++ b/test/lib/compile/csdl2openapi.test.js
@@ -103,6 +103,22 @@ describe('Edge cases', function () {
         assert.deepStrictEqual(openapi, expected, 'Empty CSDL document');
     })
 
+    it('tags object exists and it does not have duplicates', function () {
+        const csdl = {
+            $EntityContainer: 'this.Container',
+            this: {
+                ET: { $Kind: 'EntityType', $Key: ['key'], key
+                : {} },
+                Container: {
+                    Set: { $Type: 'this.ET', $Collection: true }
+                }
+            }
+        };
+        const openapi = lib.csdl2openapi(csdl, {});
+        assert.ok(openapi.tags, 'Tags object exists');
+        assert.strictEqual(openapi.tags.length, 1, 'Tags object does not have duplicates');
+    })
+
     it('omit unused types', function () {
         const csdl = {
             $Reference: { dummy: { '$Include': [{ '$Namespace': 'Org.OData.Core.V1', '$Alias': 'Core' }] } },

--- a/test/lib/compile/openapi.test.js
+++ b/test/lib/compile/openapi.test.js
@@ -147,7 +147,6 @@ service CatalogService {
 
     const openAPI = toOpenApi(csn);
     expect(openAPI).toBeDefined();
-    console.log(openAPI.tags);
     expect(openAPI.tags.length).toBe(1);
   });
 

--- a/test/lib/compile/openapi.test.js
+++ b/test/lib/compile/openapi.test.js
@@ -117,6 +117,40 @@ describe('OpenAPI export', () => {
     expect(filesFound).toMatchObject(new Set(['.odata', '.rest']));
   });
 
+  test('Check for tags object having any duplicate entries ', () => {
+    const csn = cds.compile.to.csn(`
+      namespace my.sample;
+service CatalogService {
+
+    @title: 'Auditable Fields'
+    aspect Auditable {
+        createdAt  : Timestamp;
+        createdBy  : String;
+        modifiedAt : Timestamp;
+        modifiedBy : String;
+    }
+    entity Products : Auditable {
+        key ID          : UUID;
+            name        : String;
+            description : String;
+            price       : Decimal(10, 2);
+    }
+    entity Orders : Auditable {
+        key ID          : UUID;
+            orderDate   : Date;
+            totalAmount : Decimal(10, 2);
+            product     : Association to Products;
+    }
+
+}
+    `);
+
+    const openAPI = toOpenApi(csn);
+    expect(openAPI).toBeDefined();
+    console.log(openAPI.tags);
+    expect(openAPI.tags.length).toBe(1);
+  });
+
   test('multiple services', () => {
     const csn = cds.compile.to.csn(`
       service A {entity E { key ID : UUID; };};


### PR DESCRIPTION
Tags object is now put in a set to address error of duplicates in tags:
![image](https://github.com/user-attachments/assets/03b32b5b-ca53-4d9d-b9b8-1e2060129c30)
