### PR TITLE
OpenAPI: Revert changes from PR #42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Fixed allowedValues on all primitive types.
 - Removed duplicates in `tags`.
+- No longer append protocol and service name information to the server URL incase of `openapi:servers` option.
 
 ## Version 1.0.7 - 17.10.2024
 

--- a/lib/compile/csdl2openapi.js
+++ b/lib/compile/csdl2openapi.js
@@ -96,7 +96,7 @@ module.exports.csdl2openapi = function (
         'x-sap-api-type': 'ODATAV4',
         'x-odata-version': csdl.$Version,
         'x-sap-shortText': getShortText(csdl, entityContainer),
-        servers: getServers(serviceRoot, serversObject, csdl),
+        servers: getServers(serviceRoot, serversObject),
         tags: entityContainer ? getTags(entityContainer) : {},
         paths: entityContainer ? getPaths(entityContainer) : {},
         components: getComponents(csdl, entityContainer)
@@ -564,21 +564,13 @@ module.exports.csdl2openapi = function (
      * @param {object} serversObject Input servers object
      * @return {Array} The list of servers
      */
-    function getServers(serviceRoot, serversObject, csdl) {
+    function getServers(serviceRoot, serversObject) {
         let servers;
-
-        if (serversObject && csdl.$EntityContainer ) {
+        if (serversObject) {
             try {
-              servers = JSON.parse(serversObject);
-              // if csdl.$Version is 4.01 then protocol is rest if it is less than 4.01 then protocol is odata
-              const protocol = csdl.$Version <= "4.01" ? "odata/v4" : "rest";
-              const serviceName = nameParts(csdl.$EntityContainer).qualifier;
-              // append /protocol/{$serviceName} to the URL    
-              servers.forEach((server) => {
-                server.url = server.url + "/" + protocol + "/" + serviceName;
-              });
+                servers = JSON.parse(serversObject);
             } catch (err) {
-              throw new Error(`The input server object is invalid.`);
+                throw new Error(`The input server object is invalid.`);
             }
 
             if (!servers.length) {

--- a/test/lib/compile/openapi.test.js
+++ b/test/lib/compile/openapi.test.js
@@ -254,7 +254,7 @@ service CatalogService {
     const serverObj = "[{\n \"url\": \"https://{customer1Id}.saas-app.com:{port}/v2\",\n \"variables\": {\n \"customer1Id\": \"demo\",\n \"description\": \"Customer1 ID assigned by the service provider\"\n }\n}, {\n \"url\": \"https://{customer2Id}.saas-app.com:{port}/v2\",\n \"variables\": {\n \"customer2Id\": \"demo\",\n \"description\": \"Customer2 ID assigned by the service provider\"\n }\n}]"
     const openapi = toOpenApi(csn, { 'openapi:servers': serverObj });
     expect(openapi.servers).toBeTruthy();
-    expect(openapi.servers[0].url).toMatch('https://{customer1Id}.saas-app.com:{port}/v2/odata/v4/A')
+    expect(openapi.servers[0].url).toMatch('https://{customer1Id}.saas-app.com:{port}/v2')
   });
 
 
@@ -277,7 +277,7 @@ service CatalogService {
     );
     const openapi = toOpenApi(csn, { 'openapi:config-file': path.resolve("./test/lib/compile/data/configFile.json") });
     expect(openapi.servers).toBeTruthy();
-    expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080/rest/A' }, { url: "http://foo.bar:8080/a/foo/rest/A" }] });
+    expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080' }, { url: "http://foo.bar:8080/a/foo" }] });
     expect(openapi.info.description).toMatch(/yuml.*diagram/i); 
     expect(openapi['x-odata-version']).toMatch('4.1');
   });
@@ -296,7 +296,7 @@ service CatalogService {
     expect(openapi.info.title).toMatch(/http:\/\/example.com:8080/i)
     expect(openapi.info.description).not.toMatch(/yuml.*diagram/i);
     expect(openapi['x-odata-version']).toMatch('4.0');
-    expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080/odata/v4/A' }, { url: "http://foo.bar:8080/a/foo/odata/v4/A" }] });
+    expect(openapi).toMatchObject({ servers: [{ url: 'http://foo.bar:8080' }, { url: "http://foo.bar:8080/a/foo" }] });
   });
 
   test('annotations: root entity property', () => {


### PR DESCRIPTION
As per the discussion for [the issue ](https://github.tools.sap/cap/issues/issues/17070), reverting the change of appending the protocol and serviceName.

> The URLs provided via command line options --openapi:url or --openapi:servers should be taken literally without appending protocol and service name.
>  
> These URLs tell where the service is deployed, and CAP should not make any assumptions on the deployment URL, nor impose any path conventions on how applications want to deploy their CAP microservice.
>  
> If none of these command line options is provided, the default URL of course needs to match the default URL of the CAP runtime, which now includes protocol and service name.
> 