### PR TITLE
Fix: Server URL update based on OData version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.1.1 - tbd
+
+### Fixed
+
+- Fixes server URL based on the version provided by `--odata-version` value.
+
 ## Version 1.1.0 - 04.12.2024
 
 ### Added

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -106,7 +106,7 @@ function toOpenApiOptions(csdl, csn, options = {}) {
     }
   }
 
-  const protocols = _getProtocols(csdl, csn);
+  const protocols = _getProtocols(csdl, csn, result["odataVersion"]);
 
   if (result.url) {
     const servicePaths = _servicePath(csdl, csn, protocols);
@@ -127,13 +127,19 @@ function toOpenApiOptions(csdl, csn, options = {}) {
   return result;
 }
 
-function _getProtocols(csdl, csn) {
+function _getProtocols(csdl, csn, odataVersion) {
   if (csdl.$EntityContainer) {
     const serviceName = csdl.$EntityContainer.replace(/\.[^.]+$/, "");
     const service = csn.definitions[serviceName];
     let protocols = [];
 
-    if (!service["@protocol"]) {
+    if(odataVersion === "4.01"){
+      protocols.push("rest");
+    }
+    else if(odataVersion === "4.0"){
+      protocols.push("odata");
+    }
+    else if (!service["@protocol"]) {
       protocols.push("rest"); //taking rest as default in case no relevant protocol is there
     } else if (service["@protocol"] === "none") {
       // if @protocol is 'none' then throw an error

--- a/test/lib/compile/openapi.test.js
+++ b/test/lib/compile/openapi.test.js
@@ -247,6 +247,14 @@ service CatalogService {
     expect(openapi.servers).toBeTruthy();
   });
 
+  test('options: odata-version check server URL', () => {
+    const csn = cds.compile.to.csn(`
+      service A {entity E { key ID : UUID; };};`
+    );
+    const openapi = toOpenApi(csn, { 'odata-version': '4.0' });
+    expect(openapi.servers[0].url).toMatch('odata');
+  });
+
   test('options: Multiple servers', () => {
     const csn = cds.compile.to.csn(`
       service A {entity E { key ID : UUID; };};`


### PR DESCRIPTION
Currently when no protocol is generated the server URL is default to `/rest/`.

When `odata-version` option is given then `4.01` should have `/rest/` and `4.0` should have `/odata/v4/`.

This PR has the fix for this above implementation.
