### PR TITLE
[CDSADAPTERS-2186] Fixed openapi filename issue when there's only one service in the CDL source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+### Fixed
+
+- Fixed the filename issue: when there is only one service in the CDL source, the OpenAPI document is now generated with the filename corresponding to the service name rather than the CDL source filename.
+
 ## Version 1.1.1 - 13.12.2024
 
 ### Fixed
@@ -38,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - OpenAPI documents can now have `externalDocs` object provided through `@OpenAPI.externalDocs` annotation in the service level of CDS.
 - OpenAPI documents now throws warning if `securitySchemas` are not found.
+- Introduced --openapi:config-file option to incorporate all the options for cds compile command in a JSON configuration file, inline options take precedence over those defined in the configuration file.
 
 ## Version 1.0.6 - 23.09.2024
 
@@ -90,4 +96,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Initial release
-- Introduced --openapi:config-file option to incorporate all the options for cds compile command in a JSON configuration file, inline options take precedence over those defined in the configuration file.

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -20,10 +20,6 @@ module.exports = function processor(csn, options = {}) {
     openApiDocs = _getOpenApi(csdl, openApiOptions);
   }
 
-  if (Object.keys(openApiDocs).length == 1) {
-    return openApiDocs[Object.keys(openApiDocs)[0]];
-  }
-
   return _iterate(openApiDocs);
 }
 
@@ -50,6 +46,12 @@ function* _iterate(openApiDocs) {
   }
 }
 
+function nameParts(qualifiedName) {
+  const pos = qualifiedName.lastIndexOf('.');
+  console.assert(pos > 0, 'Invalid qualified name ' + qualifiedName);
+  return qualifiedName.substring(0, pos);
+}
+
 function _getOpenApi(csdl, options, serviceName = "") {
   const openApiDocs = {};
   let filename;
@@ -67,6 +69,10 @@ function _getOpenApi(csdl, options, serviceName = "") {
     sOptions["url"] = url;
 
     const openapi = csdl2openapi.csdl2openapi(csdl, sOptions);
+
+    if(!serviceName) {
+      serviceName= nameParts(csdl.$EntityContainer);
+    }
 
     if (protocols.length > 1) {
       filename = serviceName + "." + protocol;


### PR DESCRIPTION
Fixed the openAPI filename issue when there is only one service in the CDL source. It was taking the CDL source filename instead of the service name as its filename.