### PR TITLE
[CDSADAPTERS-2186] Fixed openapi filename issue when there's only one service in the CDL source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.1.2 - tbd
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+
+### Fixed
+
+- Fixed the filename issue: when there is only one service in the CDL source, the OpenAPI document is now generated with the filename corresponding to the service name rather than the CDL source filename.
+
 ## Version 1.1.1 - 13.12.2024
 
 ### Fixed
@@ -38,6 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - OpenAPI documents can now have `externalDocs` object provided through `@OpenAPI.externalDocs` annotation in the service level of CDS.
 - OpenAPI documents now throws warning if `securitySchemas` are not found.
+- Introduced --openapi:config-file option to incorporate all the options for cds compile command in a JSON configuration file, inline options take precedence over those defined in the configuration file.
 
 ## Version 1.0.6 - 23.09.2024
 
@@ -90,4 +96,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Initial release
-- Introduced --openapi:config-file option to incorporate all the options for cds compile command in a JSON configuration file, inline options take precedence over those defined in the configuration file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 1.1.1 - tbd
+## Version 1.1.1 - 13.12.2024
 
 ### Fixed
 

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -14,13 +14,18 @@ module.exports = function processor(csn, options = {}) {
   let openApiDocs = {};
 
   if (csdl[Symbol.iterator]) { // generator function means multiple services
-    openApiDocs = _getOpenApiForMultipleServices(csdl, csn, options)
+    openApiDocs = _getOpenApiForMultipleServices(csdl, csn, options);
+    return _iterate(openApiDocs);
   } else {
-    const openApiOptions = toOpenApiOptions(csdl, csn, options)
-    openApiDocs = _getOpenApi(csdl, openApiOptions);
+    const openApiOptions = toOpenApiOptions(csdl, csn, options);
+    const serviceName = csdl.$EntityContainer.replace(/\.[^.]+$/, "");
+    openApiDocs = _getOpenApi(csdl, openApiOptions,serviceName);
+    if(Object.keys(openApiDocs).length===1){
+      return openApiDocs[serviceName];
+    }else{
+      return _iterate(openApiDocs);
+    }
   }
-
-  return _iterate(openApiDocs);
 }
 
 function _getOpenApiForMultipleServices(csdl, csn, options) {
@@ -46,12 +51,6 @@ function* _iterate(openApiDocs) {
   }
 }
 
-function nameParts(qualifiedName) {
-  const pos = qualifiedName.lastIndexOf('.');
-  console.assert(pos > 0, 'Invalid qualified name ' + qualifiedName);
-  return qualifiedName.substring(0, pos);
-}
-
 function _getOpenApi(csdl, options, serviceName = "") {
   const openApiDocs = {};
   let filename;
@@ -69,10 +68,6 @@ function _getOpenApi(csdl, options, serviceName = "") {
     sOptions["url"] = url;
 
     const openapi = csdl2openapi.csdl2openapi(csdl, sOptions);
-
-    if(!serviceName) {
-      serviceName= nameParts(csdl.$EntityContainer);
-    }
 
     if (protocols.length > 1) {
       filename = serviceName + "." + protocol;

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -20,10 +20,6 @@ module.exports = function processor(csn, options = {}) {
     openApiDocs = _getOpenApi(csdl, openApiOptions);
   }
 
-  if (Object.keys(openApiDocs).length == 1) {
-    return openApiDocs[Object.keys(openApiDocs)[0]];
-  }
-
   return _iterate(openApiDocs);
 }
 
@@ -50,6 +46,12 @@ function* _iterate(openApiDocs) {
   }
 }
 
+function nameParts(qualifiedName) {
+  const pos = qualifiedName.lastIndexOf('.');
+  console.assert(pos > 0, 'Invalid qualified name ' + qualifiedName);
+  return qualifiedName.substring(0, pos);
+}
+
 function _getOpenApi(csdl, options, serviceName = "") {
   const openApiDocs = {};
   let filename;
@@ -67,6 +69,10 @@ function _getOpenApi(csdl, options, serviceName = "") {
     sOptions["url"] = url;
 
     const openapi = csdl2openapi.csdl2openapi(csdl, sOptions);
+
+    if(!serviceName) {
+      serviceName= nameParts(csdl.$EntityContainer);
+    }
 
     if (protocols.length > 1) {
       filename = serviceName + "." + protocol;

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -18,7 +18,7 @@ module.exports = function processor(csn, options = {}) {
     return _iterate(openApiDocs);
   } else {
     const openApiOptions = toOpenApiOptions(csdl, csn, options);
-    const serviceName = csdl.$EntityContainer.replace(/\.[^.]+$/, "");
+    const serviceName = csdl.$EntityContainer.replace(/\.[^.]+$/, "");  //to get the serviceName if there is only one service
     openApiDocs = _getOpenApi(csdl, openApiOptions,serviceName);
     if(Object.keys(openApiDocs).length===1){
       return openApiDocs[serviceName];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/openapi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CAP tool for OpenAPI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixed the openAPI filename issue when there is only one service in the CDL source. It was taking the CDL source filename instead of the service name as its filename.