### PR TITLE
Adding odata-v4 in the allowed list of protocols supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Version 1.1.2 - tbd
 
+### Added
+
+- Now supports `odata-v4` protocol in the `@protocol` allowed values in CDS along with `odata` and `rest`.
+
 ### Fixed
 
 - Fixed the filename issue: when there is only one service in the CDL source, the OpenAPI document is now generated with the filename corresponding to the service name rather than the CDL source filename.

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -149,7 +149,7 @@ function _getProtocols(csdl, csn, odataVersion) {
       );
     } else if (
       service["@protocol"] === "rest" ||
-      service["@protocol"] === "odata"
+      service["@protocol"] === "odata" || service["@protocol"] === "odata-v4"
     ) {
       protocols.push(service["@protocol"]);
     } else if (Array.isArray(service["@protocol"])) {


### PR DESCRIPTION
This PR contains the fix for the issue - https://github.tools.sap/cap/issues/issues/17281