### PR TITLE
Test matrix on Node 20 and 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [22, 20]
+        node: [24, 20]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We [currently support](https://cap.cloud.sap/docs/releases/schedule) Node 20 - 24 and thus should test with the oldest and newest version