### PR TITLE
Workflow to check test coverage passes a threshold

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,6 +1,6 @@
 name: Test & Check Coverage
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Total Coverage: $COVERAGE%"
 
           # Minimum allowed coverage
-          THRESHOLD=100.0
+          THRESHOLD=95.0
 
           # Use bc to compare floats
           COMPARE=$(echo "$COVERAGE < $THRESHOLD" | bc)

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,49 @@
+name: Test & Check Coverage
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install project dependencies
+        run: npm ci
+
+      - name: Install lcov-total and bc
+        run: |
+          npm install -g lcov-total
+          sudo apt-get update
+          sudo apt-get install -y bc
+
+      - name: Run tests and generate coverage
+        run: >
+          node --test
+          --experimental-test-coverage
+          --test-reporter=lcov
+          --test-reporter-destination=lcov.info
+
+      - name: Check coverage against threshold
+        run: |
+          COVERAGE=$(lcov-total lcov.info)
+          echo "Total Coverage: $COVERAGE%"
+
+          # Minimum allowed coverage
+          THRESHOLD=95.0
+
+          # Use bc to compare floats
+          COMPARE=$(echo "$COVERAGE < $THRESHOLD" | bc)
+          if [ "$COMPARE" -eq 1 ]; then
+            echo "❌ Coverage ($COVERAGE%) is below threshold ($THRESHOLD%)"
+            exit 1
+          else
+            echo "✅ Coverage ($COVERAGE%) meets threshold ($THRESHOLD%)"
+          fi

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Total Coverage: $COVERAGE%"
 
           # Minimum allowed coverage
-          THRESHOLD=95.0
+          THRESHOLD=100.0
 
           # Use bc to compare floats
           COMPARE=$(echo "$COVERAGE < $THRESHOLD" | bc)

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 24
 
       - name: Install project dependencies
-        run: npm ci
+        run: npm i
 
       - name: Install lcov-total and bc
         run: |


### PR DESCRIPTION
Checks whether the total test coverage is above a certain threshold. The threshold is currently set to 95%.
Failing runs look like this: https://github.com/cap-js/openapi/actions/runs/18185659578/job/51769353146?pr=87

Note that the tool `lcov-total` used to assess the coverage does not provide branch coverage. So if that is important to us, we need to look for other tools to achieve that.