### PR TITLE
Workflow to check test & branch coverage passes a threshold

### DIFF
--- a/.github/scripts/check-coverage.js
+++ b/.github/scripts/check-coverage.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+
+const LCOV_FILE = 'lcov.info';
+const LINE_THRESHOLD = parseFloat(process.env.COVERAGE_THRESHOLD_LINE ?? '90.0');
+const BRANCH_THRESHOLD = parseFloat(process.env.COVERAGE_THRESHOLD_BRANCH ?? '90.0');
+
+
+let totalLinesFound = 0;
+let totalLinesHit = 0;
+let totalBranchesFound = 0;
+let totalBranchesHit = 0;
+
+try {
+  const lcov = fs.readFileSync(LCOV_FILE, 'utf-8');
+  const lines = lcov.split('\n');
+
+  for (const line of lines) {
+    if (line.startsWith('LF:')) {
+      totalLinesFound += parseInt(line.slice(3), 10);
+    } else if (line.startsWith('LH:')) {
+      totalLinesHit += parseInt(line.slice(3), 10);
+    } else if (line.startsWith('BRF:')) {
+      totalBranchesFound += parseInt(line.slice(4), 10);
+    } else if (line.startsWith('BRH:')) {
+      totalBranchesHit += parseInt(line.slice(4), 10);
+    }
+  }
+
+  const lineCoverage = totalLinesFound > 0
+    ? (totalLinesHit / totalLinesFound) * 100
+    : 100;
+
+  const branchCoverage = totalBranchesFound > 0
+    ? (totalBranchesHit / totalBranchesFound) * 100
+    : 100;
+
+  console.log(`Line Coverage:   ${lineCoverage.toFixed(2)}%`);
+  console.log(`Branch Coverage: ${branchCoverage.toFixed(2)}%`);
+
+  let failed = false;
+
+  if (lineCoverage < LINE_THRESHOLD) {
+    console.error(`❌ Line coverage below threshold (${lineCoverage.toFixed(2)}% < ${LINE_THRESHOLD}%)`);
+    failed = true;
+  }
+
+  if (branchCoverage < BRANCH_THRESHOLD) {
+    console.error(`❌ Branch coverage below threshold (${branchCoverage.toFixed(2)}% < ${BRANCH_THRESHOLD}%)`);
+    failed = true;
+  }
+
+  process.exit(failed ? 1 : 0);
+
+} catch (err) {
+  console.error(`❌ Error reading or parsing ${LCOV_FILE}:`, err.message);
+  process.exit(2);
+}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,6 +1,8 @@
-name: Test & Check Coverage
+name: Test & Branch Coverage Check
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [main]
 
 jobs:
   test:
@@ -15,35 +17,14 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install project dependencies
-        run: npm i
-
-      - name: Install lcov-total and bc
-        run: |
-          npm install -g lcov-total
-          sudo apt-get update
-          sudo apt-get install -y bc
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests and generate coverage
-        run: >
-          node --test
-          --experimental-test-coverage
-          --test-reporter=lcov
-          --test-reporter-destination=lcov.info
+        run: npm run gen:coverage
 
-      - name: Check coverage against threshold
-        run: |
-          COVERAGE=$(lcov-total lcov.info)
-          echo "Total Coverage: $COVERAGE%"
-
-          # Minimum allowed coverage
-          THRESHOLD=95.0
-
-          # Use bc to compare floats
-          COMPARE=$(echo "$COVERAGE < $THRESHOLD" | bc)
-          if [ "$COMPARE" -eq 1 ]; then
-            echo "❌ Coverage ($COVERAGE%) is below threshold ($THRESHOLD%)"
-            exit 1
-          else
-            echo "✅ Coverage ($COVERAGE%) meets threshold ($THRESHOLD%)"
-          fi
+      - name: Check line and branch coverage thresholds
+        env:
+          COVERAGE_THRESHOLD_LINE: 95
+          COVERAGE_THRESHOLD_BRANCH: 95
+        run: node .github/scripts/check-coverage.js

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,6 +1,6 @@
 name: Test & Check Coverage
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Total Coverage: $COVERAGE%"
 
           # Minimum allowed coverage
-          THRESHOLD=100.0
+          THRESHOLD=95.0
 
           # Use bc to compare floats
           COMPARE=$(echo "$COVERAGE < $THRESHOLD" | bc)

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -25,6 +25,6 @@ jobs:
 
       - name: Check line and branch coverage thresholds
         env:
-          COVERAGE_THRESHOLD_LINE: 100
-          COVERAGE_THRESHOLD_BRANCH: 95
+          COVERAGE_THRESHOLD_LINE: 95
+          COVERAGE_THRESHOLD_BRANCH: 100
         run: node .github/scripts/check-coverage.js

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,4 +1,4 @@
-name: Test & Branch Coverage Check
+name: Branch & Test Coverage Check
 
 on:
   pull_request:
@@ -25,6 +25,6 @@ jobs:
 
       - name: Check line and branch coverage thresholds
         env:
-          COVERAGE_THRESHOLD_LINE: 95
+          COVERAGE_THRESHOLD_LINE: 100
           COVERAGE_THRESHOLD_BRANCH: 95
         run: node .github/scripts/check-coverage.js

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Check line and branch coverage thresholds
         env:
           COVERAGE_THRESHOLD_LINE: 95
-          COVERAGE_THRESHOLD_BRANCH: 100
+          COVERAGE_THRESHOLD_BRANCH: 95
         run: node .github/scripts/check-coverage.js

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,49 @@
+name: Test & Check Coverage
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install project dependencies
+        run: npm ci
+
+      - name: Install lcov-total and bc
+        run: |
+          npm install -g lcov-total
+          sudo apt-get update
+          sudo apt-get install -y bc
+
+      - name: Run tests and generate coverage
+        run: >
+          node --test
+          --experimental-test-coverage
+          --test-reporter=lcov
+          --test-reporter-destination=lcov.info
+
+      - name: Check coverage against threshold
+        run: |
+          COVERAGE=$(lcov-total lcov.info)
+          echo "Total Coverage: $COVERAGE%"
+
+          # Minimum allowed coverage
+          THRESHOLD=95.0
+
+          # Use bc to compare floats
+          COMPARE=$(echo "$COVERAGE < $THRESHOLD" | bc)
+          if [ "$COMPARE" -eq 1 ]; then
+            echo "❌ Coverage ($COVERAGE%) is below threshold ($THRESHOLD%)"
+            exit 1
+          else
+            echo "✅ Coverage ($COVERAGE%) meets threshold ($THRESHOLD%)"
+          fi

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 24
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i
 
       - name: Run tests and generate coverage
         run: npm run gen:coverage

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Total Coverage: $COVERAGE%"
 
           # Minimum allowed coverage
-          THRESHOLD=95.0
+          THRESHOLD=100.0
 
           # Use bc to compare floats
           COMPARE=$(echo "$COVERAGE < $THRESHOLD" | bc)

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 24
 
       - name: Install project dependencies
-        run: npm ci
+        run: npm i
 
       - name: Install lcov-total and bc
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 gen/
 out/
 @cds-models/
+lcov.info

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "test": "node --test",
     "lint": "npx eslint .",
-    "check:types": "npx tsc"
+    "check:types": "npx tsc",
+    "gen:coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "dependencies": {
     "pluralize": "^8.0.0"


### PR DESCRIPTION
Supersedes https://github.com/cap-js/openapi/pull/87

Both thresholds are set to 95%.
Includes branch coverage

Test coverage fail looks like this: https://github.com/cap-js/openapi/actions/runs/18186062456/job/51770511566?pr=88
Branch coverage fail like this: https://github.com/cap-js/openapi/actions/runs/18186082679/job/51770566511?pr=88