### PR TITLE
Fix: Reading json files from project root

### DIFF
--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -93,8 +93,14 @@ function toOpenApiOptions(csdl, csn, options = {}) {
   }
 
   if (result["config-file"]) {
-    if (fs.existsSync(result["config-file"])) {
-      const fileContent = require(result["config-file"]);
+    if (!fs.existsSync(result["config-file"])) {
+      throw new Error("Unable to find openapi config file " + result["config-file"]);
+    }
+
+    try{
+      const fileData = fs.readFileSync(result["config-file"]);
+      const fileContent = JSON.parse(fileData);
+      
       Object.keys(fileContent).forEach((key) => {
         if (key === "odata-version" && !result["odataVersion"]) {
           result["odataVersion"] = fileContent[key];
@@ -104,8 +110,8 @@ function toOpenApiOptions(csdl, csn, options = {}) {
           result[key] = JSON.stringify(fileContent[key]);
         }
       });
-    } else {
-      throw new Error("Error while parsing the openapi configuration file " + result["config-file"]);
+    }catch(err){
+      throw new Error("Unable to parse OpenAPI config " + result["config-file"], { cause: err });
     }
   }
 


### PR DESCRIPTION
Previously the OpenAPI compiler attempted to `require()` the config file directly. This caused `MODULE_NOT_FOUND` errors when using `--openapi:config-file` option.

This patch:
- Changed `require()` to `fs.readFileSync()` with `JSON.parse()`.
- Early Return when file does not exists.

# Issue

When compiling my CAP project to openapi, I was getting an issue where compile would crash stating `Error: Cannot find module './openapi.json'`

## Expected Behavour
CDS compiles to openapi using the provided config file.

## Actual Behavour
The compilation fails with the attached log.

## Environment
- Node: v24.8.0
- NPM: 11.6.0
- OS: Linux arch 6.16.8-arch2-1 SMP PREEMPT_DYNAMIC Sun, 21 Sep 2025 23:19:08 +0000 x86_64 GNU/Linux
- @sap/cds: 9.3.1
- @cap-js/openapi: 1.2.3

## Steps to repoduce

1. Start a new project. `mkdir cap-test && cd cap-test`
2. `cds init`
3. `cds a tiny-sample`
4. `npm i -D @cap-js/openapi`
5. Create file `openapi.json` in project root with the following content:

```json
{
	"servers": [
		{
			"url": "https://example.com",
			"description": "Example"
		}
	]
}
```
6. Run `DEBUG=all cds compile srv -s all -o docs --to openapi --openapi:config-file ./openapi.json`

## Logs

```
[cds] - @sap/cds 9.3.1 loaded: ~/git/cap-test/node_modules/@sap/cds
[cds] - Command resolved: ~/git/cap-test/node_modules/@sap/cds-dk/bin/compile/index.js
[cds.env] - loading config for { context: 'cds', cwd: '~/git/cap-test' }
[cds.env] - checking {
  file: '~/git/cap-test/node_modules/@sap/cds-fiori/.cdsrc.yaml'
}
[cds.env] - checking {
  file: '~/git/cap-test/node_modules/@sap/cds-fiori/.cdsrc.json'
}
[cds.env] - checking {
  file: '~/git/cap-test/node_modules/@sap/cds-fiori/.cdsrc.js'
}
[cds.env] - checking {
  file: '~/git/cap-test/node_modules/@sap/cds-fiori/package.json'
}
[cds.env] - importing ~/git/cap-test/node_modules/@sap/cds-fiori/package.json
[cds.env] - checking { file: '~/.cdsrc.json' }
[cds.env] - checking { file: '~/.cdsrc.js' }
[cds.env] - checking { file: '~/git/cap-test/.cdsrc.yaml' }
[cds.env] - checking { file: '~/git/cap-test/.cdsrc.json' }
[cds.env] - checking { file: '~/git/cap-test/.cdsrc.js' }
[cds.env] - checking { file: '~/git/cap-test/package.json' }
[cds.env] - checking { file: '~/git/cap-test/.cdsrc-private.json' }
[cds.env] - checking { file: '~/git/cap-test/default-env.json' }
[cds.env] - checking { file: '~/git/cap-test/.env' }
[trace] - require cds.compiler  : 39.677ms
[trace] - cds.compile *.cds     : 51.465ms
[trace] - cds.compile 2edm      : 88.209ms
Error: Cannot find module './openapi.json'
Require stack:
- ~/git/cap-test/node_modules/@cap-js/openapi/lib/compile/index.js
- ~/git/cap-test/node_modules/@cap-js/openapi/index.js
- ~/git/cap-test/node_modules/@sap/cds-dk/lib/cds.js
- ~/git/cap-test/node_modules/@sap/cds-dk/lib/index.js
- ~/git/cap-test/node_modules/@sap/cds-dk/bin/cds.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1420:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1058:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1063:22)
    at Module._load (node:internal/modules/cjs/loader:1226:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:244:24)
    at Module.require (node:internal/modules/cjs/loader:1503:12)
    at require (node:internal/modules/helpers:152:16)
    at toOpenApiOptions (~/git/cap-test/node_modules/@cap-js/openapi/lib/compile/index.js:96:27)
    at _getOpenApiForMultipleServices (~/git/cap-test/node_modules/@cap-js/openapi/lib/compile/index.js:38:28) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '~/git/cap-test/node_modules/@cap-js/openapi/lib/compile/index.js',
    '~/git/cap-test/node_modules/@cap-js/openapi/index.js',
    '~/git/cap-test/node_modules/@sap/cds-dk/lib/cds.js',
    '~/git/cap-test/node_modules/@sap/cds-dk/lib/index.js',
    '~/git/cap-test/node_modules/@sap/cds-dk/bin/cds.js'
  ]
}
```