### PR TITLE
fix(csdl): correct key parameter description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Prioritize `@Core.LongDescription` over `@Core.Description` for key parameter descriptions to avoid concatenation.
+
+
 
 ## Version 1.2.3 - 28.05.2025
 

--- a/lib/compile/csdl2openapi.js
+++ b/lib/compile/csdl2openapi.js
@@ -1248,8 +1248,7 @@ see [Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-prot
             const propertyType = property.$Type;
             segment += pathValuePrefix(propertyType) + '{' + parameter + suffix + '}' + pathValueSuffix(propertyType);
             const param = {
-                description: [property[meta.voc.Core.Description], property[meta.voc.Core.LongDescription]].filter(t => t).join('  \n')
-                    || 'key: ' + parameter,
+                description: property[meta.voc.Core.LongDescription] || property[meta.voc.Core.Description] || 'key: ' + parameter,
                 in: 'path',
                 name: parameter + suffix,
                 required: true,


### PR DESCRIPTION
Align key parameter description with other properties to remove inconsistent concatenation behavior.