### PR TITLE
chore: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -3,77 +3,71 @@ description: File a bug/issue
 title: "[BUG] <title>"
 labels: ["bug", "new"]
 body:
-- type: checkboxes
-  attributes:
-    label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered.
-    options:
-    - label: I have searched the existing issues
-      required: true
-- type: textarea
-  attributes:
-    label: Current Behavior
-    description: A concise description of what you're experiencing.
-  validations:
-    required: false
-- type: textarea
-  attributes:
-    label: Expected Behavior
-    description: A concise description of what you expected to happen. Please do not put "I expect it to work" or similar! Instead, provide how you think the tool should behave/ what the output should look like to remedy the issue you ran into.
-  validations:
-    required: false
-- type: textarea
-  attributes:
-    label: Steps To Reproduce
-    description: |
-      Steps to reproduce the behavior.
-      Make sure to include all entities, `using` statements, etc. to make it a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)
-      Tip: You can add CDS code in code fences:
-      <pre>
-      ```cds
-      entity Foo {
-        bar: String;
-        baz: Integer;
-      }
-      ```
-      </pre>
-    placeholder: |
-      1. In this environment...
-      2. With this config...
-      3. With this sample model...
-      4. Run '...'/ Do...
-      5. See error...
-  validations:
-    required: false
-- type: textarea
-  attributes:
-    label: Environment
-    description: |
-      You can acquire the input for the cds-field by running `cds v -i`.
-      The version of `@cap-js/openapi` can be acquired by running `npx @cap-js/openapi --version`.
-    value: |
-        - **OS**:
-        - **Node**:
-        - **npm**:
-        - **@cap-js/openapi**:
-        - **cds**:
-    render: markdown
-  validations:
-    required: false
-- type: textarea
-  attributes:
-    label: Repository Containing a Minimal Reproducible Example
-    placeholder: https://github.com/my/repository
-    description: |
-      Do you have a sample repository where we can observe the reported behaviour?
-  validations:
-    required: false
-- type: textarea
-  attributes:
-    label: Anything else?
-    description: |
-      Links? References? Anything that will give us more context about the issue you are encountering!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen. Please do not put "I expect it to work" or similar! Instead, provide how you think the tool should behave/ what the output should look like to remedy the issue you ran into.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: |
+        Steps to reproduce the behavior.
+        Make sure to include all entities, `using` statements, etc. to make it a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)
+        
+        Tip: You can add CDS code in code fences with ```cds
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. With this sample model...
+        4. Run '...'/ Do...
+        5. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        You can acquire the input for the cds-field by running `cds v -i`.
+        The version of `@cap-js/openapi` can be acquired by running `npx @cap-js/openapi --version`.
+      value: |
+          - **OS**:
+          - **Node**:
+          - **npm**:
+          - **@cap-js/openapi**:
+          - **cds**:
+      render: markdown
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Repository Containing a Minimal Reproducible Example
+      placeholder: https://github.com/my/repository
+      description: |
+        Do you have a sample repository where we can observe the reported behaviour?
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
 
-      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
-  validations:
-    required: false
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,4 +1,3 @@
----
 name: 💡 Feature Request
 description: Request a missing feature
 title: "[FEATURE] <title>"

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -3,9 +3,9 @@ description: Ask a question
 title: "[QUESTION] <title>"
 labels: ["question", "new"]
 body:
-- type: textarea
-  attributes:
-    label: Question
-    description: What would you like to know? If you encounter unusual behaviour or identified a missing feature, consider opening a bug report instead.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Question
+      description: What would you like to know? If you encounter unusual behaviour or identified a missing feature, consider opening a bug report instead.
+    validations:
+      required: true


### PR DESCRIPTION
Introduce issue templates for bug reports, features requests, and questions to streamline incoming issues.
Forms have been lifted from https://github.com/cap-js/cds-typer with slight modifications where needed. So you can see them in action [over there](https://github.com/cap-js/cds-typer/issues/new/choose).