### PR TITLE
Separate event emitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-const { compileToOpenAPI, events } = require('./lib/compile');
+const { compileToOpenAPI, events, emitter } = require('./lib/compile');
 
 module.exports = {
     compile: compileToOpenAPI,
-    events
+    events,
+    emitter
 }

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -1,8 +1,11 @@
+const EventEmitter = require('events');
 const csdl2openapi = require('./csdl2openapi')
 const cds = require('@sap/cds');
 const fs = require("fs");
 const DEBUG = cds.debug('openapi');
 const supportedProtocols = ["rest", "odata", "odata-v4"];
+
+const emitter = new EventEmitter()
 
 const events = /** @type {const} */({
   /**
@@ -25,9 +28,9 @@ const events = /** @type {const} */({
 });
 
 function compileToOpenAPI(csn, options = {}) {
-  cds.emit(events.before, { csn, options });
+  emitter.emit(events.before, { csn, options });
   const result = processor(csn, options);
-  cds.emit(events.after, { csn, options, result });
+  emitter.emit(events.after, { csn, options, result });
   return result;
 }
 
@@ -228,5 +231,6 @@ function _servicePath(csdl, csn, protocols) {
 
 module.exports = {
   compileToOpenAPI,
-  events
+  events,
+  emitter
 }


### PR DESCRIPTION
Stacked on https://github.com/cap-js/openapi/pull/112

This PR showcases an alternative emitter approach. Instead of going through a centralised `cds.on` emitter, OpenAPI exposes its own `EventEmitter` instance. Repetition can be eliminated by deconstruting the import:

```js
// cds-plugin.js
const cds = require('@sap/cds');
const { openapi } = cds.compile.to;

openapi.on(openapi.events.before, ({ csn, options }) => {
    // …
})
```
or
```js
// cds-plugin.js
const cds = require('@sap/cds');
const { on, event } = cds.compile.to.openapi;

on(events.before, ({ csn, options }) => {
	// …
})
```

Note that this change would require adjustments in cds-dk, where `cds.compile.to.openapi` is exposed. `cds-dk/pull/3944`