### PR TITLE
chore: Add prepare-next-version workflow

### DIFF
--- a/.github/workflows/prepare-next-version.yml
+++ b/.github/workflows/prepare-next-version.yml
@@ -1,0 +1,32 @@
+
+name: Prepare Next Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: Increment version
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+
+
+jobs:
+  prepare-next-version:
+    uses: cap-js/.github/.github/workflows/prepare-next-version.yml@main
+    secrets: inherit
+    with:
+      increment: ${{ github.event.inputs.increment }}


### PR DESCRIPTION
Reuse https://github.com/cap-js/.github/blob/main/.github/workflows/prepare-next-version.yml

Creates new PR to bump version in package.json and set version topmost section in changelog.md. Also adds a new, empty section there for the next version.