### PR TITLE
fix: restore bound operations on containment navigation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Deprecated
 ### Removed
 ### Fixed
+- Restore bound actions/functions on containment navigation paths (regression since v1.2.0)
 ### Security
 
 ## [1.4.0] - 2026-03-18

--- a/lib/compile/csdl2openapi.js
+++ b/lib/compile/csdl2openapi.js
@@ -1339,8 +1339,7 @@ see [Expand](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-prot
      * @param {boolean} byKey read by key
      */
     function pathItemsForBoundOperations(paths, prefix, prefixParameters, element, sourceName, byKey = false) {
-        //ignore operations on navigation path
-        if (element.$Kind === "NavigationProperty") {
+        if (element.$Kind === "NavigationProperty" && !element.$ContainsTarget) {
             return;
         }
         const overloads = meta.boundOverloads[element.$Type + (!byKey && element.$Collection ? '-c' : '')] || [];

--- a/scripts/regenerate.js
+++ b/scripts/regenerate.js
@@ -13,7 +13,8 @@ const specialOptions = {
         host: 'services.odata.org',
         basePath: '/V4/(S(cnbm44wtbc1v5bgrlek5lpcc))/TripPinServiceRW',
         diagram: true
-    }
+    },
+    'autoexposed-texts': {}
 };
 
 // Default options for all other test cases.

--- a/test/lib/compile/data/TripPin.openapi3.json
+++ b/test/lib/compile/data/TripPin.openapi3.json
@@ -1216,6 +1216,53 @@
         }
       }
     },
+    "/Me/Trips({TripId_1})/Microsoft.OData.SampleService.Models.TripPin.GetInvolvedPeople": {
+      "get": {
+        "summary": "Invokes function GetInvolvedPeople",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "description": "key: TripId",
+            "in": "path",
+            "name": "TripId_1",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Collection of Person",
+                  "properties": {
+                    "@count": {
+                      "$ref": "#/components/schemas/count"
+                    },
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Me/Trips({TripId_1})/Photos": {
       "parameters": [
         {
@@ -2511,6 +2558,62 @@
         "responses": {
           "204": {
             "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/People('{UserName}')/Trips({TripId_1})/Microsoft.OData.SampleService.Models.TripPin.GetInvolvedPeople": {
+      "get": {
+        "summary": "Invokes function GetInvolvedPeople",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "description": "key: UserName",
+            "in": "path",
+            "name": "UserName",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "key: TripId",
+            "in": "path",
+            "name": "TripId_1",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "title": "Collection of Person",
+                  "properties": {
+                    "@count": {
+                      "$ref": "#/components/schemas/count"
+                    },
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Microsoft.OData.SampleService.Models.TripPin.Person"
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/error"

--- a/test/lib/compile/data/containment.openapi3.json
+++ b/test/lib/compile/data/containment.openapi3.json
@@ -2452,6 +2452,143 @@
         }
       }
     },
+    "/TheWhole/Many({index_1})/self.Like": {
+      "post": {
+        "summary": "I like this part",
+        "tags": [
+          "The Whole"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "parameters": [
+          {
+            "description": "key: index",
+            "in": "path",
+            "name": "index_1",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/TheWhole/Many({index_1})/self.Likes": {
+      "get": {
+        "summary": "How many like this part",
+        "tags": [
+          "The Whole"
+        ],
+        "parameters": [
+          {
+            "description": "key: index",
+            "in": "path",
+            "name": "index_1",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "integer",
+                      "format": "int32",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/TheWhole/Many/self.Like": {
+      "post": {
+        "summary": "I like all of these parts",
+        "tags": [
+          "The Whole"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/TheWhole/Many/self.Likes": {
+      "get": {
+        "summary": "How many like these parts",
+        "tags": [
+          "The Whole"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "integer",
+                      "format": "int32",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/TheWhole/One": {
       "get": {
         "summary": "Retrieves one of a the whole.",
@@ -2854,6 +2991,63 @@
         "responses": {
           "204": {
             "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/TheWhole/One/self.Like": {
+      "post": {
+        "summary": "I like this part",
+        "tags": [
+          "The Whole"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/TheWhole/One/self.Likes": {
+      "get": {
+        "summary": "How many like this part",
+        "tags": [
+          "The Whole"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "integer",
+                      "format": "int32",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/error"
@@ -3994,6 +4188,182 @@
         }
       }
     },
+    "/Wholes('{ID}')/Many({index_1})/self.Like": {
+      "post": {
+        "summary": "I like this part",
+        "tags": [
+          "Wholes"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "parameters": [
+          {
+            "description": "key: ID",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "key: index",
+            "in": "path",
+            "name": "index_1",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Wholes('{ID}')/Many({index_1})/self.Likes": {
+      "get": {
+        "summary": "How many like this part",
+        "tags": [
+          "Wholes"
+        ],
+        "parameters": [
+          {
+            "description": "key: ID",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "key: index",
+            "in": "path",
+            "name": "index_1",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "integer",
+                      "format": "int32",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Wholes('{ID}')/Many/self.Like": {
+      "post": {
+        "summary": "I like all of these parts",
+        "tags": [
+          "Wholes"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "parameters": [
+          {
+            "description": "key: ID",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Wholes('{ID}')/Many/self.Likes": {
+      "get": {
+        "summary": "How many like these parts",
+        "tags": [
+          "Wholes"
+        ],
+        "parameters": [
+          {
+            "description": "key: ID",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "integer",
+                      "format": "int32",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/Wholes('{ID}')/One": {
       "parameters": [
         {
@@ -4438,6 +4808,84 @@
         "responses": {
           "204": {
             "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
+    "/Wholes('{ID}')/One/self.Like": {
+      "post": {
+        "summary": "I like this part",
+        "tags": [
+          "Wholes"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/error"
+          }
+        },
+        "parameters": [
+          {
+            "description": "key: ID",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Wholes('{ID}')/One/self.Likes": {
+      "get": {
+        "summary": "How many like this part",
+        "tags": [
+          "Wholes"
+        ],
+        "parameters": [
+          {
+            "description": "key: ID",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "integer",
+                      "format": "int32",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/error"

--- a/test/lib/compile/data/descriptions.openapi3.json
+++ b/test/lib/compile/data/descriptions.openapi3.json
@@ -813,6 +813,70 @@
         "description": "Delete Contained - LongDescription"
       }
     },
+    "/entities('{id}')/contained('{id_1}')/self.action": {
+      "post": {
+        "summary": "Action Bound Overload Ext subEntity - Description",
+        "tags": [
+          "entities"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "418": {
+            "description": "Out of coffee on bound action call on subEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "description": "Action Bound Overload subEntity - LongDescription",
+        "parameters": [
+          {
+            "description": "Property - LongDescription",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 70,
+              "default": "0000"
+            }
+          },
+          {
+            "description": "key: id",
+            "in": "path",
+            "name": "id_1",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 70
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nonbinding": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Action Bound Overload Non-Binding Parameter subEntity - LongDescription"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/entities('{id}')/related": {
       "parameters": [
         {
@@ -1600,6 +1664,70 @@
         "description": "Delete Contained Ext - LongDescription"
       }
     },
+    "/entities_ext('{id}')/contained('{id_1}')/self.action": {
+      "post": {
+        "summary": "Action Bound Overload Ext subEntity - Description",
+        "tags": [
+          "entities ext"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "418": {
+            "description": "Out of coffee on bound action call on subEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "description": "Action Bound Overload subEntity - LongDescription",
+        "parameters": [
+          {
+            "description": "Property - LongDescription",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 70,
+              "default": "0000"
+            }
+          },
+          {
+            "description": "key: id",
+            "in": "path",
+            "name": "id_1",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 70
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nonbinding": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Action Bound Overload Non-Binding Parameter subEntity - LongDescription"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/entities_ext('{id}')/related": {
       "parameters": [
         {
@@ -2385,6 +2513,59 @@
         "description": "Singleton Delete Contained - LongDescription"
       }
     },
+    "/single/contained('{id_1}')/self.action": {
+      "post": {
+        "summary": "Action Bound Overload Ext subEntity - Description",
+        "tags": [
+          "single"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "418": {
+            "description": "Out of coffee on bound action call on subEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "description": "Action Bound Overload subEntity - LongDescription",
+        "parameters": [
+          {
+            "description": "key: id",
+            "in": "path",
+            "name": "id_1",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 70
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nonbinding": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Action Bound Overload Non-Binding Parameter subEntity - LongDescription"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/single/related": {
       "get": {
         "summary": "Singleton Query Related - Description",
@@ -2939,6 +3120,59 @@
           }
         },
         "description": "Singleton Delete Contained Ext - LongDescription"
+      }
+    },
+    "/single_ext/contained('{id_1}')/self.action": {
+      "post": {
+        "summary": "Action Bound Overload Ext subEntity - Description",
+        "tags": [
+          "single ext"
+        ],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "418": {
+            "description": "Out of coffee on bound action call on subEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        },
+        "description": "Action Bound Overload subEntity - LongDescription",
+        "parameters": [
+          {
+            "description": "key: id",
+            "in": "path",
+            "name": "id_1",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 70
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Action parameters",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nonbinding": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Action Bound Overload Non-Binding Parameter subEntity - LongDescription"
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/single_ext/related": {


### PR DESCRIPTION
This fixes a bug where actions on navigation properties are missing (regression since 1.2.0).